### PR TITLE
Character and dynasty importer rewrites

### DIFF
--- a/ImperatorToCk2/DataFiles/defaultOutput/localization/culture_loc.csv
+++ b/ImperatorToCk2/DataFiles/defaultOutput/localization/culture_loc.csv
@@ -1,42 +1,42 @@
 #CODE;ENGLISH;FRENCH;GERMAN;;SPANISH;;;;;;;;;x
-#Translations done by PKZB
-thracian;Thracian;Thrace;Thracisch;;Tracio;;;;;;;;;x
-sabellian;Sabellian;Sabéllienne;Sabellisch;;Sabelio;;;;;;;;;x
-old_ligurian;Ligurian;Ligure;Ligurisch;;Ligurio;;;;;;;;;x
-venetic;Venetic;Vénétique;Venetisch;;Venético;;;;;;;;;x
-siculian;Siculian;Sicule;Siculisch;;Siceliota;;;;;;;;;x
-etruscan;Etruscan;Étrusque;Etruscisch;;Etrusco;;;;;;;;;x
-nuragic;Nuragic;Nuragique;Nuragisch;;Nurágico;;;;;;;;;x
-rhaetian;Rhaetian;Rhétique;Rhaetisch;;Rético;;;;;;;;;x
-lepontic;Lepontic;Lépontique;Lepontisch;;Lepóntio;;;;;;;;;x
-gallic;Gallic;Gaulois;Gallisch;;Galo;;;;;;;;;x
-celtic_pannonian;Noric;Norique;Norisch;;Nórico;;;;;;;;;x
-belgae;Belgae;Belge;Belgisch;;Belga;;;;;;;;;x
-manx;Manx;Mannoise;Manxisch;;Manx;;;;;;;;;x
-carthaginian;Punic;Punique;Punisch;;Púnico;;;;;;;;;x
-phoenician;Phoenician;Phénicienne;Phoenicisch;;Fenicio;;;;;;;;;x
-vandal;Vandal;Vandale;Vandalisch;;Vándalo;;;;;;;;;x
-gothic;Gothic;Goth;Gothisch;;Godo;;;;;;;;;x
-ancient_egyptian;Ancient Egyptian;Ancien Égyptienne;Altägyptisch;;Antiguo Egipcio;;;;;;;;;x
-nabatean;Nabatean;Nabatéen;Nabatisch;;Nabateo;;;;;;;;;x
-hebrew;Hebrew;Hébreu;Hebrewisch;;Hebreo;;;;;;;;;x
-dacian;Dacian;Dace;Dacisch;;Dacio;;;;;;;;;x
-caucasian_albanian;Caucasian Albanian;Caucaso-Albanienne;Kaucasischalbanisch;;Cáucasoalbanés;;;;;;;;;x
-iberic;Iberic;Ibérique;Iberisch;;Ibérico;;;;;;;;;x
-turdetanian;Turdetanian;Turdétane;Turdetanisch;;Turdetanio;;;;;;;;;x
-celtiberian;Celtiberian;Celtibérique;Keltiberisch;;Celtibérico;;;;;;;;;x
-lusitanian;Lusitanian;Lusitanienne;Lusitanisch;;Lusitano;;;;;;;;;x
-lycian;Lycian;Lycienne;Lycisch;;Licio;;;;;;;;x
-phrygian;Phrygian;Phrygienne;Phrygisch;;Frigio;;;;;;;;;x
-isaurian;Isaurian;Isaurienne;Isaurisch;;Isauro;;;;;;;;;x
-paphlagonian;Paphlagonian;Paphlagonienne;Paphlagonisch;;Palaíta;;;;;;;;;x
-cilician;Cilician;Cilicienne;Cilicisch;;Cilicio;;;;;;;;;x
-babylonian;Babylonian;Babylonienne;Babylonisch;;Babilonio;;;;;;;;;x
+#French and Spanish translations done by PKZB
+thracian;Thracian;Thrace;Thracische;;Tracio;;;;;;;;;x
+sabellian;Sabellian;Sabéllienne;Sabellische;;Sabelio;;;;;;;;;x
+old_ligurian;Ligurian;Ligure;Ligurische;;Ligurio;;;;;;;;;x
+venetic;Venetic;Vénétique;Venetische;;Venético;;;;;;;;;x
+siculian;Siculian;Sicule;Siculische;;Siceliota;;;;;;;;;x
+etruscan;Etruscan;Étrusque;Etruscische;;Etrusco;;;;;;;;;x
+nuragic;Nuragic;Nuragique;Nuragische;;Nurágico;;;;;;;;;x
+rhaetian;Rhaetian;Rhétique;Rhaetische;;Rético;;;;;;;;;x
+lepontic;Lepontic;Lépontique;Lepontische;;Lepóntio;;;;;;;;;x
+gallic;Gallic;Gaulois;Gallische;;Galo;;;;;;;;;x
+celtic_pannonian;Noric;Norique;Norische;;Nórico;;;;;;;;;x
+belgae;Belgae;Belge;Belgische;;Belga;;;;;;;;;x
+manx;Manx;Mannoise;Manxische;;Manx;;;;;;;;;x
+carthaginian;Punic;Punique;Punische;;Púnico;;;;;;;;;x
+phoenician;Phoenician;Phénicienne;Phoenicische;;Fenicio;;;;;;;;;x
+vandal;Vandal;Vandale;Vandalische;;Vándalo;;;;;;;;;x
+gothic;Gothic;Goth;Gothische;;Godo;;;;;;;;;x
+ancient_egyptian;Ancient Egyptian;Ancien Égyptienne;Altägyptische;;Antiguo Egipcio;;;;;;;;;x
+nabatean;Nabatean;Nabatéen;Nabatische;;Nabateo;;;;;;;;;x
+hebrew;Hebrew;Hébreu;Hebrewische;;Hebreo;;;;;;;;;x
+dacian;Dacian;Dace;Dacische;;Dacio;;;;;;;;;x
+caucasian_albanian;Caucasian Albanian;Caucaso-Albanienne;Kaucasischalbanische;;Cáucasoalbanés;;;;;;;;;x
+iberic;Iberic;Ibérique;Iberische;;Ibérico;;;;;;;;;x
+turdetanian;Turdetanian;Turdétane;Turdetanische;;Turdetanio;;;;;;;;;x
+celtiberian;Celtiberian;Celtibérique;Keltiberische;;Celtibérico;;;;;;;;;x
+lusitanian;Lusitanian;Lusitanienne;Lusitanische;;Lusitano;;;;;;;;;x
+lycian;Lycian;Lycienne;Lycische;;Licio;;;;;;;;x
+phrygian;Phrygian;Phrygienne;Phrygische;;Frigio;;;;;;;;;x
+isaurian;Isaurian;Isaurienne;Isaurische;;Isauro;;;;;;;;;x
+paphlagonian;Paphlagonian;Paphlagonienne;Paphlagonische;;Palaíta;;;;;;;;;x
+cilician;Cilician;Cilicienne;Cilicische;;Cilicio;;;;;;;;;x
+babylonian;Babylonian;Babylonienne;Babylonische;;Babilonio;;;;;;;;;x
 
 #Culture groups
 
-punic;Punic;Punic;Punisch;;Punic;;;;;;;;;x
-pre_indo_european;Pre-Indo-European;Pre-Indo-European;Vorindoeuropänisch;;Pre-Indo-European;;;;;;;;;x
-gallic_group;Continental Celtic;Continental Celtic;Kontinentalkeltisch;;Continental Celtic;;;;;;;;;x
-dacian_group;Dacian;Dace;Dacisch;;Dacio;;;;;;;;;x
+punic;Punic;Punic;Punische;;Punic;;;;;;;;;x
+pre_indo_european;Pre-Indo-European;Pre-Indo-European;Vorindoeuropänische;;Pre-Indo-European;;;;;;;;;x
+gallic_group;Continental Celtic;Continental Celtic;Kontinentalkeltische;;Continental Celtic;;;;;;;;;x
+dacian_group;Dacian;Dace;Dacische;;Dacio;;;;;;;;;x
 east_germanic;East Germanic;East Germanic;Ost Germanische;;East Germanic;;;;;;;;;x

--- a/ImperatorToCk2/DataFiles/defaultOutput/localization/religion_loc.csv
+++ b/ImperatorToCk2/DataFiles/defaultOutput/localization/religion_loc.csv
@@ -2,23 +2,23 @@
 #Translations done by PKZB
 
 #religions
-polytheistic;Polythéiste;Polytheistic;Polytheistisch;;Politeísta;;;;;;;;;x
-canaanite;Canaanite;Canaannéenne;Kanaanisch;;Canaanita;;;;;;;;;x
-druidic;Druidic;Druidique;Druidisch;;Druídica;;;;;;;;;x
-egyptian;Kemetic;Kémitiste;Kemetisch;;Kemética;;;;;;;;;x
-zalmoxian;Zalmoxian;Zalmoxiste;Zalmoxisch;;Zalmoxista;;;;;;;;;x
-megalithic;Megalithic;Mégalithique;Megalithisch;;Megalítica;;;;;;;;;x
-iberian;Iberian;Ibérique;Iberisch;;Ibérica;;;;;;;;;x
-sumerian;Chaldean;Chaldéenne;Mespotamisch;;Caldeana;;;;;;;;;x
-arabic;Arabic;Arabique;Arabisch;;Árabe;;;;;;;;;x
-ritualistic;Ritualiste;Ritualistic;Ritualistisch;;Ritualista;;;;;;;;;x
-cybelene;Cybelene;Cybélienne;Kybelenisch;;Cibeliana;;;;;;;;;x
-khaldic;Khaldic;Khaldique;Khaldisch;;Jaldiana;;;;;;;;;x
-armazic;Armazic;Armazienne;Armazisch;;Armázica;;;;;;;;;x
-scythian;Scythian;Scythe;Scythisch;;Escita;;;;;;;;;x
+polytheistic;Polythéiste;Polytheistic;Polytheistische;;Politeísta;;;;;;;;;x
+canaanite;Canaanite;Canaannéenne;Kanaanische;;Canaanita;;;;;;;;;x
+druidic;Druidic;Druidique;Druidische;;Druídica;;;;;;;;;x
+egyptian;Kemetic;Kémitiste;Kemetische;;Kemética;;;;;;;;;x
+zalmoxian;Zalmoxian;Zalmoxiste;Zalmoxische;;Zalmoxista;;;;;;;;;x
+megalithic;Megalithic;Mégalithique;Megalithische;;Megalítica;;;;;;;;;x
+iberian;Iberian;Ibérique;Iberische;;Ibérica;;;;;;;;;x
+sumerian;Chaldean;Chaldéenne;Mespotamische;;Caldeana;;;;;;;;;x
+arabic;Arabic;Arabique;Arabische;;Árabe;;;;;;;;;x
+ritualistic;Ritualiste;Ritualistic;Ritualistische;;Ritualista;;;;;;;;;x
+cybelene;Cybelene;Cybélienne;Kybelenische;;Cibeliana;;;;;;;;;x
+khaldic;Khaldic;Khaldique;Khaldische;;Jaldiana;;;;;;;;;x
+armazic;Armazic;Armazienne;Armazische;;Armázica;;;;;;;;;x
+scythian;Scythian;Scythe;Scythische;;Escita;;;;;;;;;x
 
 #religion groups
-polytheistic;Polythéiste;Polytheistic;Polytheistisch;;Politeísta;;;;;;;;;x
+polytheistic;Polytheistic;Polythéiste;Polytheistische;;Politeísta;;;;;;;;;x
 
 #Details done by Thinking_waffle
 

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Characters.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Characters.java
@@ -56,7 +56,7 @@ public class Characters
                     endOrNot = false;
                     while (flag == 0) {
                         qaaa = scnr.nextLine();
-                        if (qaaa.split("=")[0].equals( tab+tab+"name" ) ) {
+                        if (qaaa.split("=")[0].equals( tab+tab+"name" ) || qaaa.split("=")[0].equals( tab+tab+"custom_name" )) {
                             output[0] = qaaa.split("=")[1];
                             output[0] = output[0].substring(1,output[0].length()-1);
                         }
@@ -208,3 +208,4 @@ public class Characters
     
     }
 }
+

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Characters.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Characters.java
@@ -1,4 +1,4 @@
-package ImperatorToCK2; 
+//package ImperatorToCK2; 
 
 import java.util.Scanner;
 import java.io.IOException;
@@ -6,6 +6,7 @@ import java.io.FileInputStream;
 import java.io.PrintWriter;
 import java.io.FileOutputStream;
 import java.util.Random;
+import java.util.ArrayList;
 /**
  * Everything dealing with characters
  *
@@ -16,7 +17,7 @@ public class Characters
 {
     private int x;
 
-    public static String[] importChar (String name, String charID) throws IOException
+    public static ArrayList<String[]> importChar (String name) throws IOException
     {
 
         String tab = "	";
@@ -27,9 +28,11 @@ public class Characters
 
         int flag = 0;
 
-        String keyWord = charID+"={";
+        String keyWord = "1={";
 
         int aqq = 0;
+
+        ArrayList<String[]> impCharList= new ArrayList<String[]>();
 
         boolean endOrNot = true;
         String vmm = scnr.nextLine();
@@ -44,6 +47,10 @@ public class Characters
         output[4] = "m"; //by default all characters are male, unless specified to be female
         output[7] = "q"; //default for no dynasty
         output[8] = "q"; //default for no traits
+        output[10] = "0"; //default for no martial
+        output[11] = "0"; //default for no finesse
+        output[12] = "0"; //default for no charisma
+        output[13] = "0"; //default for no zeal
         output[14] = "0"; //default for unmarried character
         output[15] = "0"; //default for character with no children
         output[16] = "0"; //default for minor character with no family name
@@ -52,94 +59,125 @@ public class Characters
             while (endOrNot = true){
 
                 qaaa = scnr.nextLine();
-                if (qaaa.equals(keyWord)){
-                    endOrNot = false;
-                    while (flag == 0) {
-                        qaaa = scnr.nextLine();
-                        if (qaaa.split("=")[0].equals( tab+tab+"name" ) || qaaa.split("=")[0].equals( tab+tab+"custom_name" )) {
-                            output[0] = qaaa.split("=")[1];
-                            output[0] = output[0].substring(1,output[0].length()-1);
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"family_name" ) ) {
-                            output[16] = qaaa.split("=")[1];
-                            output[16] = output[16].substring(1,output[16].length()-1);
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"culture" ) ) {
-                            output[1] = qaaa.split("=")[1];
-                            output[1] = output[1].substring(1,output[1].length()-1);
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"religion" ) ) {
-                            output[2] = qaaa.split("=")[1];
-                            output[2] = output[2].substring(1,output[2].length()-1);
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"family" ) ) {
-                            output[7] = qaaa.split("=")[1];
+                flag = 0;
+                //endOrNot = false;
+                while (flag == 0) {
+                    qaaa = scnr.nextLine();
 
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"traits" ) ) {
-                            Output.logPrint (qaaa); 
-                            output[8] = qaaa.split("=")[1];
+                    if (qaaa.split("=")[0].equals( tab+tab+"name" ) || qaaa.split("=")[0].equals( tab+tab+"custom_name" )) {
+                        output[0] = qaaa.split("=")[1];
+                        output[0] = output[0].substring(1,output[0].length()-1);
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"family_name" ) ) {
+                        output[16] = qaaa.split("=")[1];
+                        output[16] = output[16].substring(1,output[16].length()-1);
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"culture" ) ) {
+                        output[1] = qaaa.split("=")[1];
+                        output[1] = output[1].substring(1,output[1].length()-1);
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"religion" ) ) {
+                        output[2] = qaaa.split("=")[1];
+                        output[2] = output[2].substring(1,output[2].length()-1);
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"family" ) ) {
+                        output[7] = qaaa.split("=")[1];
 
-                            output[8] = output[8].substring(2,output[8].length()-2);
-                            Output.logPrint (output[8]);
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+tab+"martial" ) ) {
-                            output[10] = qaaa.split("=")[1];
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+tab+"finesse" ) ) {
-                            output[11] = qaaa.split("=")[1];
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+tab+"charisma" ) ) {
-                            output[12] = qaaa.split("=")[1];
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+tab+"zeal" ) ) {
-                            output[13] = qaaa.split("=")[1];
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"spouse" ) ) {
-                            output[14] = qaaa.split("=")[1];
-                            output[14] = output[14].substring(2,output[14].length()-2); 
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"traits" ) ) {
+                        output[8] = qaaa.split("=")[1];
 
-                            try {
-                                if (output[14].split(" ")[1] != null) {
-                                    output[14] = output[14].split(" ")[output[14].split(" ").length-1];   
-                                }
-                            }catch (java.lang.ArrayIndexOutOfBoundsException exception) {
+                        output[8] = output[8].substring(2,output[8].length()-2);
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+tab+"martial" ) ) {
+                        output[10] = qaaa.split("=")[1];
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+tab+"finesse" ) ) {
+                        output[11] = qaaa.split("=")[1];
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+tab+"charisma" ) ) {
+                        output[12] = qaaa.split("=")[1];
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+tab+"zeal" ) ) {
+                        output[13] = qaaa.split("=")[1];
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"spouse" ) ) {
+                        output[14] = qaaa.split("=")[1];
+                        output[14] = output[14].substring(2,output[14].length()-2); 
 
+                        try {
+                            if (output[14].split(" ")[1] != null) {
+                                output[14] = output[14].split(" ")[output[14].split(" ").length-1];   
                             }
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"children" ) ) {
-
-                
-                            output[15] = qaaa.split("=")[1];
-                            output[15] = output[15].substring(2,output[15].length()-2);    
+                        }catch (java.lang.ArrayIndexOutOfBoundsException exception) {
 
                         }
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"children" ) ) {
 
-                        //popTotal
-                        else if (qaaa.split("=")[0].equals( tab+"age" ) ) {
-                            aqq = aqq + 1;
-                            output[3] = qaaa.split("=")[1];
+                        output[15] = qaaa.split("=")[1];
+                        output[15] = output[15].substring(2,output[15].length()-2);    
+
+                    }
+
+                    //popTotal
+                    else if (qaaa.split("=")[0].equals( tab+"age" ) ) {
+                        aqq = aqq + 1;
+                        output[3] = qaaa.split("=")[1];
+                    }
+
+                    //might be used or ignored
+                    else if (qaaa.equals( tab+"female=yes" ) ) {
+                        aqq = aqq + 1;
+                        output[4] = "f";
+                    }
+
+                    else if (qaaa.split("=")[0].equals( tab+"death_date" ) ) {
+                        aqq = aqq + 1;
+                        flag = 1; //end loop, babies which die don't have any experience field
+                        output[4] = output[4]+"_"+qaaa.split("=")[1];
+                        output[6] = "0";
+                    }
+
+                    else if (qaaa.split("=")[0].equals( tab+"character_experience" ) ) {
+                        aqq = aqq + 1;
+                        flag = 1; //end loop
+                        output[6] = qaaa.split("=")[1];
+                    }
+                    
+                    else if (qaaa.split("=")[0].equals( Integer.toString(impCharList.size()+1) ) ) { //Somehow has gone past checks, immediately end
+                        aqq = aqq + 1;
+                        flag = 1; //end loop
+                        output[6] = "0";
+                    }
+
+                    if (flag == 1) {
+
+                        String[] tmpOutput = new String[output.length];
+
+                        int aq2 = 0;
+
+                        while (aq2 < output.length) {
+                            tmpOutput[aq2] = output[aq2];
+                            aq2 = aq2 + 1;
                         }
 
-                        //might be used or ignored
-                        else if (qaaa.equals( tab+"female=yes" ) ) {
-                            aqq = aqq + 1;
-                            output[4] = "f";
-                        }
+                        impCharList.add(tmpOutput);
 
-                        else if (qaaa.split("=")[0].equals( tab+"death_date" ) ) {
-                            aqq = aqq + 1;
-                            flag = 1; //end loop, babies which die don't have any experience field
-                            output[4] = output[4]+"_"+qaaa.split("=")[1];
-                            output[6] = "0";
-                        }
-
-                        else if (qaaa.split("=")[0].equals( tab+"character_experience" ) ) {
-                            aqq = aqq + 1;
-                            flag = 1; //end loop
-                            output[6] = qaaa.split("=")[1];
-                        }
-
+                        output[0] = "noName"; //default for no owner, uncolonized province
+                        output[1] = "noCulture"; //default for no culture, uncolonized province with 0 pops
+                        output[2] = "noReligion"; //default for no religion, uncolonized province with 0 pops
+                        output[3] = "30"; //default age
+                        output[4] = "m"; //by default all characters are male, unless specified to be female
+                        output[7] = "q"; //default for no dynasty
+                        output[8] = "q"; //default for no traits
+                        output[10] = "0"; //default for no martial
+                        output[11] = "0"; //default for no finesse
+                        output[12] = "0"; //default for no charisma
+                        output[13] = "0"; //default for no zeal
+                        output[14] = "0"; //default for unmarried character
+                        output[15] = "0"; //default for character with no children
+                        output[16] = "0"; //default for minor character with no family name
                     }
 
                 }
@@ -150,10 +188,11 @@ public class Characters
 
         }   
 
-        return output;
-    
+        return impCharList;
+
     }
-    public static String importAndConvDynasty (String dir, String IDnum, String backupName, String file) throws IOException
+
+    public static ArrayList<String> importDynasty (String file) throws IOException
     {
 
         String tab = "	";
@@ -163,32 +202,49 @@ public class Characters
 
         int flag = 0;
 
-        String keyWord = tab+tab+IDnum;
-
         int aqq = 0;
         boolean endOrNot = true;
         String vmm = scnr.nextLine();
         String qaaa = vmm;
         String output = "noName"; //default for no name
 
-      
+        ArrayList<String> dynList= new ArrayList<String>();
+
+        String id = "0";
+
         try {
-            while (endOrNot = true){
+            try {
+                while (endOrNot = true){
 
-                qaaa = scnr.nextLine();
-                if (qaaa.split("=")[0].equals(keyWord)){
-                    endOrNot = false;
-                    while (flag == 0) {
-                        qaaa = scnr.nextLine();
-                        if (qaaa.split("=")[0].equals( tab+tab+tab+"key" ) ) {
-                            output = qaaa.split("=")[1];
-                            output = output.substring(1,output.length()-1);
-                            flag = 1;
+                    qaaa = scnr.nextLine();
+                    if (qaaa.equals(tab+tab+"}")) {
+                        int flag1 = 0;
+                        while (flag1 == 0) {
+                            qaaa = scnr.nextLine();
+                            if (qaaa.split("=")[0].equals( tab+tab+tab+"key" )) {
+                                flag1 = 1;
+                            } 
+                            else {
+                                id = qaaa.split(tab+tab)[1];
+                                id = id.split("=")[0];
+                            }
+
                         }
+                    }
+                    if (qaaa.split("=")[0].equals( tab+tab+tab+"key" )) {
 
+                        output = qaaa.split("=")[1];
+                        output = output.substring(1,output.length()-1);
+                        String tmpOutput = output+","+id;
+                        dynList.add(tmpOutput);
+                        output = "noName"; //default for no name
+                        aqq = aqq + 1;
+                        //flag = 1;
                     }
 
                 }
+            }catch(java.lang.ArrayIndexOutOfBoundsException exception) {
+                endOrNot = false;
             }
 
         }catch (java.util.NoSuchElementException exception){
@@ -196,16 +252,22 @@ public class Characters
 
         }   
 
-        if (output.split("_")[0].equals ("minor")) {
-            output = backupName;
+        return dynList;
+    }
+    
+    public static String searchDynasty (ArrayList<String> dynList, String id) throws IOException //searches dynList for id
+    {
+        int aqq = 0;
+        
+        while (aqq < dynList.size()) {
+            String[] dyn = dynList.get(aqq).split(",");
+            if (dyn[1].equals(id)) {
+                return dyn[0];
+            } else {
+                aqq = aqq + 1;
+            }
         }
 
-        IDnum = Integer.toString(Integer.parseInt(IDnum) + 700000000);  
-
-        Output.dynastyCreation(output,IDnum,dir);
-        return output;
-
-    
+        return id;
     }
 }
-

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Characters.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Characters.java
@@ -1,4 +1,4 @@
-//package ImperatorToCK2; 
+package ImperatorToCK2; 
 
 import java.util.Scanner;
 import java.io.IOException;

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Importer.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Importer.java
@@ -1,4 +1,5 @@
 package ImperatorToCK2; 
+
 import java.util.Scanner;
 import java.io.IOException;
 import java.io.FileInputStream;
@@ -89,7 +90,7 @@ public class Importer
                         }
 
                         if (qaaa.split("=")[0].equals( tab+"}" ) ) { //ends here
-                            //flag = 1; //end loop
+                            
 
                             String[] tmpOutput = new String[output.length];
 
@@ -136,7 +137,7 @@ public class Importer
 
         String bracket1 = VQ2.substring(0,1);
         String bracket2 = VQ2.substring(1,2);
-        //String tagID = Integer.toString(natIDnum);
+        
         //System.out.println ("Load 1 done");
         FileInputStream fileIn= new FileInputStream(name);
         Scanner scnr= new Scanner(fileIn);
@@ -189,7 +190,7 @@ public class Importer
                 qaaa = scnr.nextLine();
                 if (vmm.equals(startWord)){
 
-                    //endOrNot = false;  
+                    
                     while (flag == 0) {
                         qaaa = scnr.nextLine(); 
 
@@ -318,7 +319,7 @@ public class Importer
                                 }
 
                                 else if (qaaa.split("=")[0].equals( tab+tab+tab+tab+"budget_dates" ) ) {
-                                    //flag = 2; //end loop
+                                    
                                     if (output[21].equals("9999")) { //failsafe if somehow there is no historical tag
                                         output[21] = output[0];
                                     }
@@ -335,7 +336,7 @@ public class Importer
                                     impTagInfo.add(tmpOutput);
 
                                     aqq = aqq + 1;
-                                    //System.out.println(output[0] + " " + aqq);
+                                    
 
                                     output[0] = "9999"; //default for no tag
                                     output[1] = "6969"; //default for no flag seed
@@ -1048,4 +1049,5 @@ public class Importer
     }
     //developed originally by Shinymewtwo99
 }
+
 

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Importer.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Importer.java
@@ -1,4 +1,4 @@
-package ImperatorToCK2; 
+package ImperatorToCK2;   
 
 import java.util.Scanner;
 import java.io.IOException;
@@ -1049,5 +1049,3 @@ public class Importer
     }
     //developed originally by Shinymewtwo99
 }
-
-

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Importer.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Importer.java
@@ -1,5 +1,4 @@
 package ImperatorToCK2; 
-
 import java.util.Scanner;
 import java.io.IOException;
 import java.io.FileInputStream;
@@ -17,19 +16,21 @@ import java.util.ArrayList;
 public class Importer
 {
 
-    public static String[] importProv (String name, int provIDnum) throws IOException
+    public static ArrayList<String[]> importProv (String name) throws IOException
     {
 
-        String provID = Integer.toString(provIDnum);
+        //String provID = Integer.toString(provIDnum);
 
         FileInputStream fileIn= new FileInputStream(name);
         Scanner scnr= new Scanner(fileIn);
-        
+
+        ArrayList<String[]> impProvList= new ArrayList<String[]>();
+
         String tab = "	";
 
         int flag = 0;
 
-        String keyWord = tab+provID+"={";
+        String keyWord = tab+1+"={";
 
         int aqq = 0;
 
@@ -42,7 +43,11 @@ public class Importer
         output[0] = "9999"; //default for no owner, uncolonized province
         output[1] = "noCulture"; //default for no culture, uncolonized province with 0 pops
         output[2] = "noReligion"; //default for no religion, uncolonized province with 0 pops
+        output[3] = "0"; //default for no pops, uncolonized or uninhabitible province
+        output[4] = "{ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 }"; //default for no buildinga
         output[5] = "9999"; //default for no monument
+
+        impProvList.add(output); //default at ID 0
 
         try {
             while (endOrNot = true){
@@ -68,8 +73,7 @@ public class Importer
 
                         //popTotal
                         if (qaaa.split("=")[0].equals( tab+tab+"pop" ) ) {
-                            aqq = aqq + 1;
-                            //double aq = 1;
+                            aqq = aqq + 1; //count pop
                             output[3] = Integer.toString(aqq);
                         }
 
@@ -78,14 +82,34 @@ public class Importer
                             output[4] = qaaa.split("=")[1];
 
                         }
-                        
+
                         if (qaaa.split("=")[0].equals( tab+tab+"great_work" ) ) {
                             output[5] = qaaa.split("=")[1];
 
                         }
-                        
+
                         if (qaaa.split("=")[0].equals( tab+"}" ) ) { //ends here
-                            flag = 1; //end loop
+                            //flag = 1; //end loop
+
+                            String[] tmpOutput = new String[output.length];
+
+                            int aq2 = 0;
+
+                            while (aq2 < output.length) {
+                                tmpOutput[aq2] = output[aq2];
+                                aq2 = aq2 + 1;
+                            }
+
+                            impProvList.add(tmpOutput);
+
+                            output[0] = "9999"; //default for no owner, uncolonized province
+                            output[1] = "noCulture"; //default for no culture, uncolonized province with 0 pops
+                            output[2] = "noReligion"; //default for no religion, uncolonized province with 0 pops
+                            output[3] = "0"; //default for no pops, uncolonized or uninhabitible province
+                            output[4] = "{ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 }"; //default for no buildinga
+                            output[5] = "9999"; //default for no monument
+                            
+                            aqq = 0; //reset pop count
 
                         }
 
@@ -99,11 +123,11 @@ public class Importer
 
         }   
 
-        return output;
+        return impProvList;
 
     }
 
-    public static String[] importCountry (String name, int natIDnum) throws IOException
+    public static ArrayList<String[]> importCountry (String name) throws IOException
     {
 
         String tab = "	";
@@ -112,12 +136,15 @@ public class Importer
 
         String bracket1 = VQ2.substring(0,1);
         String bracket2 = VQ2.substring(1,2);
-        String tagID = Integer.toString(natIDnum);
+        //String tagID = Integer.toString(natIDnum);
         //System.out.println ("Load 1 done");
         FileInputStream fileIn= new FileInputStream(name);
         Scanner scnr= new Scanner(fileIn);
 
         int flag = 0;
+
+        ArrayList<String[]> impTagInfo = new ArrayList<String[]>();
+
         //double q = 0.0;
 
         //String idStr = provID.toString();
@@ -125,7 +152,7 @@ public class Importer
         String startWord = tab+"country_database={";
         String endWord = tab+"state_database={";
 
-        String keyWord = tab+tab+tagID+"={";
+        String keyWord = tab+tab+"}";
 
         int aqq = 0;
         boolean endOrNot = true;
@@ -134,9 +161,18 @@ public class Importer
         String[] output;   // Owner Culture Religeon PopTotal Buildings
         output = new String[22];
 
-        output[0] = "9999"; //default for no owner, uncolonized province
-        output[1] = "noCulture"; //default for no culture, uncolonized province with 0 pops
-        output[2] = "noReligion"; //default for no religion, uncolonized province with 0 pops
+        output[0] = "9999"; //default for no tag
+        output[1] = "6969"; //default for no flag seed
+        output[2] = "no"; //default for no gender equality laws
+        output[3] = "0 0 0"; //default for no color
+        output[4] = "0"; //default for no gold
+        output[5] = "4529"; //default for no capital (Province of Olbia)
+        output[6] = "noCulture"; //default for no culture, uncolonized province with 0 pops";
+        output[7] = "noReligion"; //default for no religion, uncolonized province with 0 pops
+        output[8] = "0"; //default for no technology
+        output[9] = "0"; //default for no technology
+        output[10] = "0"; //default for no technology
+        output[11] = "0"; //default for no technology
         output[12] = "0"; //default for no researcher, will either be a random character in CKII or no character 
         output[13] = "0"; //default for no researcher, will either be a random character in CKII or no character 
         output[14] = "0"; //default for no researcher, will either be a random character in CKII or no character 
@@ -145,18 +181,21 @@ public class Importer
         output[20] = "none"; //default for no governors/governorships, land will be directly held by the ruler
         output[21] = "9999"; //default for no historical tag used in nation formation
 
+        impTagInfo.add(output); //default entry at ID 0
+
         try {
             while (endOrNot = true){
 
                 qaaa = scnr.nextLine();
                 if (vmm.equals(startWord)){
 
-                    endOrNot = false;  
+                    //endOrNot = false;  
                     while (flag == 0) {
                         qaaa = scnr.nextLine(); 
 
                         if (qaaa.equals(keyWord)){
                             flag = 1;
+
                             while (flag == 1) {
                                 qaaa = scnr.nextLine();
                                 if (qaaa.split("=")[0].equals( tab+tab+tab+"tag" ) ) {
@@ -279,12 +318,47 @@ public class Importer
                                 }
 
                                 else if (qaaa.split("=")[0].equals( tab+tab+tab+tab+"budget_dates" ) ) {
-                                    flag = 2; //end loop
+                                    //flag = 2; //end loop
+                                    if (output[21].equals("9999")) { //failsafe if somehow there is no historical tag
+                                        output[21] = output[0];
+                                    }
+
+                                    String[] tmpOutput = new String[output.length];
+
+                                    int aq2 = 0;
+
+                                    while (aq2 < output.length) {
+                                        tmpOutput[aq2] = output[aq2];
+                                        aq2 = aq2 + 1;
+                                    }
+
+                                    impTagInfo.add(tmpOutput);
+
+                                    aqq = aqq + 1;
+                                    //System.out.println(output[0] + " " + aqq);
+
+                                    output[0] = "9999"; //default for no tag
+                                    output[1] = "6969"; //default for no flag seed
+                                    output[2] = "no"; //default for no gender equality laws
+                                    output[3] = "0 0 0"; //default for no color
+                                    output[4] = "0"; //default for no gold
+                                    output[5] = "4529"; //default for no capital (Province of Olbia)
+                                    output[6] = "noCulture"; //default for no culture, uncolonized province with 0 pops";
+                                    output[7] = "noReligion"; //default for no religion, uncolonized province with 0 pops
+                                    output[8] = "0"; //default for no technology
+                                    output[9] = "0"; //default for no technology
+                                    output[10] = "0"; //default for no technology
+                                    output[11] = "0"; //default for no technology
+                                    output[12] = "0"; //default for no researcher, will either be a random character in CKII or no character 
+                                    output[13] = "0"; //default for no researcher, will either be a random character in CKII or no character 
+                                    output[14] = "0"; //default for no researcher, will either be a random character in CKII or no character 
+                                    output[15] = "0"; //default for no researcher, will either be a random character in CKII or no character
+                                    output[16] = "0"; //default for no leader, will either be a random character in CKII or no character
+                                    output[20] = "none"; //default for no governors/governorships, land will be directly held by the ruler
+                                    output[21] = "9999"; //default for no historical tag used in nation formation
 
                                 }
-
                             }
-
                         }
                     }   
 
@@ -295,18 +369,13 @@ public class Importer
             endOrNot = false;
 
         }   
-        
-        if (output[21].equals("9999")) { //failsafe if somehow there is no historical tag
-            output[21] = output[0];
-        }
 
-        return output;
-
+        return impTagInfo;
     }
-    
+
     public static ArrayList<String> importSubjects (String name, int overlordIDnum, ArrayList<String> currentList) throws IOException
     {
-        
+
         //Primarily used for subjects/vassals in IR
 
         String overlordID = Integer.toString(overlordIDnum);
@@ -315,7 +384,7 @@ public class Importer
         Scanner scnr= new Scanner(fileIn);
 
         int flag = 0;
-        
+
         String tab = "	";
 
         String keyWord = tab+tab+"first="+overlordID;
@@ -354,7 +423,7 @@ public class Importer
                             flag = 1; //end loop
                             currentList.add(output[0]+","+output[1]+","+output[2]);
                         }
-                        
+
                         if (qaaa.split("=")[0].equals( tab+"}" ) ) { //If there isn't a subject type, prevents it from going over to the next
                             output[0] = "9999";
                             output[1] = "9999";
@@ -365,7 +434,7 @@ public class Importer
                     }
 
                 }
-                
+
                 flag = 0;
             }
 
@@ -373,7 +442,7 @@ public class Importer
             endOrNot = false;
 
         }
-        
+
         if (output[1].equals("9999") || output[2].equals("9999")) { //Fallback in case something goes wrong, subject relation won't be converted
             output[0] = "9999"; //default for no overlord, overlord has no subjects
             output[1] = "9999"; //default for no subject
@@ -383,7 +452,7 @@ public class Importer
         return currentList;
 
     }
-    
+
     public static String[] importDir (String name) throws IOException //Imports directories from configuration.txt
     {
 
@@ -640,7 +709,7 @@ public class Importer
         } else if (output[0].equals(tag)) {
             output = importAreaLocalisation(directory,tag);    
         } 
-        
+
         if (output[0].equals(tag)) { //Mod support
             output = importCustCountryLocalisation (tag);    
         }
@@ -750,7 +819,7 @@ public class Importer
         return output;
 
     }
-    
+
     public static String[] importCustCountryLocalisation (String tag) throws IOException //Supported Loc for popular IR mods
     {
 
@@ -944,7 +1013,7 @@ public class Importer
         return oldFile;
 
     }
-    
+
     public static ArrayList<String> importBasicFile (String directory) throws IOException
     {
 
@@ -979,3 +1048,4 @@ public class Importer
     }
     //developed originally by Shinymewtwo99
 }
+

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Main.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Main.java
@@ -92,6 +92,8 @@ public class Main
 
             String[] impProvInfo;   // Owner Culture Religeon PopTotal Buildings
             impProvInfo = new String[5];
+            
+            ArrayList<String[]> impProvInfoList = new ArrayList<String[]>();
 
             String[][] ck2ProvInfo;   // Array list of array lists...
             ck2ProvInfo = new String[5][8500];
@@ -217,6 +219,8 @@ public class Main
             Processing.combineProvConvList("provinceConversionCore.txt","provinceConversion.txt"); //combines old style mappings and new style mappings
 
             //processing information
+            
+            impProvInfoList = importer.importProv(saveProvinces);
             totalPop = 0;
             while (flag == 0) {
                 impProvtoCK = importer.importConvList("provinceConversion.txt",aqq); 
@@ -233,7 +237,7 @@ public class Main
                         relNum = 0;
                     }
 
-                    impProvInfo = importer.importProv(saveProvinces,aqq);
+                    impProvInfo = impProvInfoList.get(aqq);
 
                     temp = 0;
                     temp2 = 0;
@@ -404,32 +408,7 @@ public class Main
 
             ArrayList<String[]> impTagInfo = new ArrayList<String[]>();
             //Country processing
-            try{
-                while (flag == 0) {
-                    impTagInfo.add(importer.importCountry(saveCountries,aq2));
-
-                    LOGGER.info (impTagInfo.get(aq2)[0] + " " +  impTagInfo.get(aq2)[6] + " " + impTagInfo.get(aq2)[4]);
-
-                    aq2 = aq2 + 1;
-
-                    if (aq2 > 1) {
-
-                        if ( impTagInfo.get(aq2-1)[0].equals("9999")) {
-                            flagCount = flagCount + 1; //temp testing, to be removed later
-                        }
-                        else {
-                            flagCount = 0;    
-                        }
-                    }
-
-                    if (flagCount == 5) {
-                        flag = 1; //temp testing, to be removed later
-                    }
-                }
-            }catch (java.util.NoSuchElementException exception){
-                flag = 1;
-
-            }  
+            impTagInfo = importer.importCountry(saveCountries);
             
             long countryTime = System.nanoTime();
             long countryTimeTot = (((countryTime - startTime) / 1000000000)/60);
@@ -443,7 +422,7 @@ public class Main
             int aq4 = 0;
             LOGGER.config(ck2TagTotals[343]);
 
-            int totCountries = aq2;
+            int totCountries = impTagInfo.size(); //ammount of IR countries in save file
 
             impSubjectInfo = Processing.generateSubjectList(totCountries+100,saveDiplo);
 

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Main.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Main.java
@@ -1,4 +1,4 @@
-package ImperatorToCK2; 
+package ImperatorToCK2;  
 
 import java.util.Scanner;
 import java.util.ArrayList;
@@ -135,6 +135,10 @@ public class Main
             convertedCharacters.add("0"); //Debug at id 0 so list will never be empty
 
             ArrayList<String> impSubjectInfo = new ArrayList<String>(); //Overlord-Subject relations
+            
+            ArrayList<String[]> impCharInfoList = new ArrayList<String[]>();
+            
+            ArrayList<String> impDynList = new ArrayList<String>();
 
             String[] impProvRegions = Processing.importRegionList(8500,impGameDir);
 
@@ -413,7 +417,7 @@ public class Main
             long countryTime = System.nanoTime();
             long countryTimeTot = (((countryTime - startTime) / 1000000000)/60);
             LOGGER.info("Country data imported after "+countryTimeTot+" minutes");
-            LOGGER.finest("65%");
+            LOGGER.finest("55%");
 
             LOGGER.config("and the culture is" + ck2ProvInfo[1][343]);
 
@@ -423,8 +427,15 @@ public class Main
             LOGGER.config(ck2TagTotals[343]);
 
             int totCountries = impTagInfo.size(); //ammount of IR countries in save file
+            
+            LOGGER.info("Importing subject data...");
 
             impSubjectInfo = Processing.generateSubjectList(totCountries+100,saveDiplo);
+            
+            LOGGER.info("Subject data imported after "+countryTimeTot+" minutes");
+            LOGGER.finest("65%");
+            
+            LOGGER.info("Copying default output...");
 
             //Default output, will be included in every conversion regardless of what occured in the save file
             Output.output("defaultOutput"+VM+"cultures"+VM+"00_cultures.txt",modDirectory+VM+"common"+VM+"cultures"+VM+"00_cultures.txt");
@@ -503,6 +514,12 @@ public class Main
             
             int empireRank = 350; //Ammount of holdings to be Empire
             
+            impCharInfoList = Characters.importChar(saveCharacters);
+            
+            impDynList = Characters.importDynasty(saveDynasty);
+            
+            //Array
+            
             try {
                 try {
                     while (flag == 0) {
@@ -553,13 +570,17 @@ public class Main
                                 }
 
                                 LOGGER.info (impTagInfo.get(aq4)[16] + " rules " + impTagInfo.get(aq4)[0] + "_" + aq4);
-                                Character = Characters.importChar(saveCharacters,impTagInfo.get(aq4)[16]);
+                                Character = impCharInfoList.get(Integer.parseInt(impTagInfo.get(aq4)[16]));
                                 convertedCharacters = Output.characterCreation(tempNum2, Output.cultureOutput(Character[1]),Output.religionOutput(Character[2]),
                                     Character[3],Character[0],Character[7],Character[4],Character[8],Character[10],Character[11],Character[12],Character[13],Character[14],
-                                    Character[15],saveCharacters,"q","q",convertedCharacters,modDirectory);
+                                    Character[15],saveCharacters,"q","q",convertedCharacters,impCharInfoList,modDirectory);
                                 LOGGER.config ("c");
 
-                                String rulerDynasty = Characters.importAndConvDynasty(modDirectory,Character[7],Character[16],saveDynasty);
+                                String rulerDynasty = Characters.searchDynasty(impDynList,Character[7]);
+                                
+                                
+                                
+                                Output.dynastyCreation(rulerDynasty,Character[7],Character[16],modDirectory);
 
                                 String[] locName = importer.importLocalisation(impGameDir,impTagInfo.get(aq4)[19],rulerDynasty);
                                 output.localizationCreation(locName,impTagInfo.get(aq4)[0],rank,modDirectory);
@@ -585,11 +606,11 @@ public class Main
 
                                         Output.titleCreation(govRegID,governorID,Processing.randomizeColor(),"no","none",subRank,impTagInfo.get(aq4)[0],modDirectory);
 
-                                        govCharacter = Characters.importChar(saveCharacters,governor);
+                                        govCharacter = impCharInfoList.get(Integer.parseInt(governor));
 
                                         convertedCharacters = Output.characterCreation(governorID, Output.cultureOutput(govCharacter[1]),Output.religionOutput(govCharacter[2]),govCharacter[3],
                                             govCharacter[0],govCharacter[7],govCharacter[4],govCharacter[8],govCharacter[10],govCharacter[11],govCharacter[12],govCharacter[13],
-                                            govCharacter[14],govCharacter[15],saveCharacters,"q","q",convertedCharacters,modDirectory);
+                                            govCharacter[14],govCharacter[15],saveCharacters,"q","q",convertedCharacters,impCharInfoList,modDirectory);
 
                                         String[] govLocName = importer.importLocalisation(impGameDir,govReg,"00Region00");
                                         govLocName[0] = locName[1] + " " + govLocName[0];
@@ -671,9 +692,9 @@ public class Main
                             
                             LOGGER.info("Uncolonized province at ID "+aq4+", creating chiefdom of "+importedInfo[0]+" led by "+dynCharName);
 
-                            Output.dynastyCreation("of "+importedInfo[0],ruler,modDirectory);
+                            Output.dynastyCreation("of "+importedInfo[0],ruler,"debug",modDirectory);
                             Output.characterCreation(ruler,dynCult,dynRel,dynCharAge,dynCharName,ruler,"69","q","5","5","5","5","0","0",
-                                saveCharacters,"q","q",convertedCharacters,modDirectory);
+                                saveCharacters,"q","q",convertedCharacters,impCharInfoList,modDirectory);
                             String greyShade = Processing.randomizeColorGrey();
 
                             Output.titleCreation("dynamic"+aq4,ruler,greyShade,"no",Integer.toString(aq4),"d","no_liege",modDirectory);

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Output.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Output.java
@@ -1,4 +1,5 @@
 package ImperatorToCK2;
+
 import java.util.Scanner;
 import java.io.IOException;
 import java.io.FileInputStream;
@@ -463,8 +464,11 @@ public class Output
         aqq = 0;
 
         Importer importer = new Importer();
+        
+        //any filename with non-asci characters won't render in CK II, changed file output name to use GloriousCharacter instead of character name
+        //in case player created interesting names in I:R
 
-        FileOutputStream fileOut= new FileOutputStream(Directory + VM + name + "k_" + irKING + ".txt");
+        FileOutputStream fileOut= new FileOutputStream(Directory + VM + "GloriousCharacter" + "_" + irKING + ".txt");
         PrintWriter out = new PrintWriter(fileOut);
 
         int flag = 0;
@@ -757,7 +761,7 @@ public class Output
     public static void logPrint(String name) throws IOException //outputs to log.txt
     {
         
-        String logFile = "log.txt";
+        String logFile = "debugTest.txt";
 
 
         ArrayList<String> oldFile = new ArrayList<String>();
@@ -809,3 +813,4 @@ public class Output
     }
 
 }
+

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Output.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Output.java
@@ -335,7 +335,7 @@ public class Output
 
     public static ArrayList<String> characterCreation(String irKING, String cult, String rel, String age, String name, String dynasty,
     String sex, String traits, String martial, String zeal, String charisma, String finesse, String spouse, String children,String tempFile,String father,
-    String mother,ArrayList<String> convertedList,String Directory) throws IOException
+    String mother,ArrayList<String> convertedList,ArrayList<String[]> charList,String Directory) throws IOException
     {
 
         int characterCount = 0;
@@ -387,10 +387,11 @@ public class Output
         int aq4 = 0;
 
         if (spouse != "0") {//Recursively calls to get rest of family
-            spouseInfo = Characters.importChar(tempFile,spouse);
+            int spouseID = Integer.parseInt(spouse);
+            spouseInfo = charList.get(spouseID);
 
             characterCreation( spouse1066,  cultureOutput(spouseInfo[1]),  religionOutput(spouseInfo[2]),  spouseInfo[3],  spouseInfo[0],  spouseInfo[7],
-                spouseInfo[4],  spouseInfo[8],  martial,  zeal,  charisma,  finesse,  "0",  "0", tempFile,"q",  "q",convertedList, Directory);
+                spouseInfo[4],  spouseInfo[8],  martial,  zeal,  charisma,  finesse,  "0",  "0", tempFile,"q",  "q",convertedList,charList, Directory);
         }
 
         if (children != "0") {
@@ -405,13 +406,15 @@ public class Output
 
             while (aq4 < childCount) {//Recursively calls to get rest of family
 
-                childInfo = Characters.importChar(tempFile,children.split(" ")[aq4]);
+                int childID = Integer.parseInt(children.split(" ")[aq4]);
+
+                childInfo = charList.get(childID);
                 //oldlogPrint ("Child " + aq4 + " out of " + childCount);
                 child1066 = Integer.toString( 1000000 + Integer.parseInt(children.split(" ")[aq4]) );
 
                 characterCreation( child1066,  cultureOutput(childInfo[1]),  religionOutput(childInfo[2]),  childInfo[3],  childInfo[0],  childInfo[7],
                     childInfo[4],  childInfo[8],  martial,  zeal,  charisma,  finesse,  childInfo[14],  childInfo[15], tempFile,irKING,spouse1066,
-                    convertedList,Directory);
+                    convertedList,charList,Directory);
 
                 aq4 = aq4 + 1;
             }
@@ -464,7 +467,7 @@ public class Output
         aqq = 0;
 
         Importer importer = new Importer();
-        
+
         //any filename with non-asci characters won't render in CK II, changed file output name to use GloriousCharacter instead of character name
         //in case player created interesting names in I:R
 
@@ -635,7 +638,7 @@ public class Output
         return convertedList;
     }
 
-    public static String dynastyCreation(String name, String id, String Directory) throws IOException
+    public static String dynastyCreation(String name, String id, String backupName, String Directory) throws IOException
     {
 
         String VM = "\\"; 
@@ -643,8 +646,18 @@ public class Output
         char VMq = '"';
         String tab = "	";
 
+        if (name.split("_")[0].equals ("minor")) {
+            name = backupName;
+        }
+
+        if (backupName.equals("debug")) { //gives all IR character dynasties + 700000000 to prevent conflict, generated ones (debug) use + 6000000
+        } else {
+
+            id = Integer.toString(Integer.parseInt(id) + 700000000);
+        }
+
         Directory = Directory + VM + "common" + VM + "dynasties";
-        String ck2CultureInfo ="a";   // Owner Culture Religeon PopTotal Buildings
+        String ck2CultureInfo ="a";   // debug output
         FileOutputStream fileOut= new FileOutputStream(Directory + VM + "c_" + id + ".txt");
         PrintWriter out = new PrintWriter(fileOut);
 
@@ -757,17 +770,14 @@ public class Output
 
         return ck2CultureInfo;
     }
-    
+
     public static void logPrint(String name) throws IOException //outputs to log.txt
     {
-        
+
         String logFile = "debugTest.txt";
 
-
         ArrayList<String> oldFile = new ArrayList<String>();
-        
         oldFile = Importer.importBasicFile(logFile);
-
 
         FileOutputStream fileOut= new FileOutputStream(logFile);
         PrintWriter out = new PrintWriter(fileOut);
@@ -793,12 +803,11 @@ public class Output
         fileOut.close();
 
     }
-    
+
     public static void logBlank() throws IOException //creates/replaces new log file
     {
-        
-        String logFile = "log.txt";
 
+        String logFile = "log.txt";
 
         FileOutputStream fileOut= new FileOutputStream(logFile);
         PrintWriter out = new PrintWriter(fileOut);
@@ -809,8 +818,5 @@ public class Output
         out.flush();
         fileOut.close();
 
-
     }
-
 }
-


### PR DESCRIPTION
Rewrote character and dynasty importers for time efficiency. `importChar()` no longer imports a single character (`String[]`) from a save, but rather imports all characters and returns a list (`ArrayList<String[]>`) of them. Similarly with `importDynasty()`, which returns all dynasties (`String`) into a list (`ArrayList<String>`). `importDynasty()` required major structural changes to remain compatible with old 1.3 saves, so each dynasty is indexed, with their ID added to the end of the string after a comma (dynasty_name,idNum), which the new method `searchDynasty (ArrayList<String> , String)` can search through for a specific dynasty.