### PR TITLE
Character and Dynasty rewrite (fixed)

### DIFF
--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Characters.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Characters.java
@@ -6,6 +6,7 @@ import java.io.FileInputStream;
 import java.io.PrintWriter;
 import java.io.FileOutputStream;
 import java.util.Random;
+import java.util.ArrayList;
 /**
  * Everything dealing with characters
  *
@@ -16,7 +17,7 @@ public class Characters
 {
     private int x;
 
-    public static String[] importChar (String name, String charID) throws IOException
+    public static ArrayList<String[]> importChar (String name) throws IOException
     {
 
         String tab = "	";
@@ -27,9 +28,11 @@ public class Characters
 
         int flag = 0;
 
-        String keyWord = charID+"={";
+        String keyWord = "1={";
 
         int aqq = 0;
+
+        ArrayList<String[]> impCharList= new ArrayList<String[]>();
 
         boolean endOrNot = true;
         String vmm = scnr.nextLine();
@@ -44,6 +47,10 @@ public class Characters
         output[4] = "m"; //by default all characters are male, unless specified to be female
         output[7] = "q"; //default for no dynasty
         output[8] = "q"; //default for no traits
+        output[10] = "0"; //default for no martial
+        output[11] = "0"; //default for no finesse
+        output[12] = "0"; //default for no charisma
+        output[13] = "0"; //default for no zeal
         output[14] = "0"; //default for unmarried character
         output[15] = "0"; //default for character with no children
         output[16] = "0"; //default for minor character with no family name
@@ -52,94 +59,125 @@ public class Characters
             while (endOrNot = true){
 
                 qaaa = scnr.nextLine();
-                if (qaaa.equals(keyWord)){
-                    endOrNot = false;
-                    while (flag == 0) {
-                        qaaa = scnr.nextLine();
-                        if (qaaa.split("=")[0].equals( tab+tab+"name" ) || qaaa.split("=")[0].equals( tab+tab+"custom_name" )) {
-                            output[0] = qaaa.split("=")[1];
-                            output[0] = output[0].substring(1,output[0].length()-1);
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"family_name" ) ) {
-                            output[16] = qaaa.split("=")[1];
-                            output[16] = output[16].substring(1,output[16].length()-1);
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"culture" ) ) {
-                            output[1] = qaaa.split("=")[1];
-                            output[1] = output[1].substring(1,output[1].length()-1);
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"religion" ) ) {
-                            output[2] = qaaa.split("=")[1];
-                            output[2] = output[2].substring(1,output[2].length()-1);
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"family" ) ) {
-                            output[7] = qaaa.split("=")[1];
+                flag = 0;
+                //endOrNot = false;
+                while (flag == 0) {
+                    qaaa = scnr.nextLine();
 
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"traits" ) ) {
-                            Output.logPrint (qaaa); 
-                            output[8] = qaaa.split("=")[1];
+                    if (qaaa.split("=")[0].equals( tab+tab+"name" ) || qaaa.split("=")[0].equals( tab+tab+"custom_name" )) {
+                        output[0] = qaaa.split("=")[1];
+                        output[0] = output[0].substring(1,output[0].length()-1);
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"family_name" ) ) {
+                        output[16] = qaaa.split("=")[1];
+                        output[16] = output[16].substring(1,output[16].length()-1);
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"culture" ) ) {
+                        output[1] = qaaa.split("=")[1];
+                        output[1] = output[1].substring(1,output[1].length()-1);
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"religion" ) ) {
+                        output[2] = qaaa.split("=")[1];
+                        output[2] = output[2].substring(1,output[2].length()-1);
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"family" ) ) {
+                        output[7] = qaaa.split("=")[1];
 
-                            output[8] = output[8].substring(2,output[8].length()-2);
-                            Output.logPrint (output[8]);
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+tab+"martial" ) ) {
-                            output[10] = qaaa.split("=")[1];
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+tab+"finesse" ) ) {
-                            output[11] = qaaa.split("=")[1];
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+tab+"charisma" ) ) {
-                            output[12] = qaaa.split("=")[1];
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+tab+"zeal" ) ) {
-                            output[13] = qaaa.split("=")[1];
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"spouse" ) ) {
-                            output[14] = qaaa.split("=")[1];
-                            output[14] = output[14].substring(2,output[14].length()-2); 
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"traits" ) ) {
+                        output[8] = qaaa.split("=")[1];
 
-                            try {
-                                if (output[14].split(" ")[1] != null) {
-                                    output[14] = output[14].split(" ")[output[14].split(" ").length-1];   
-                                }
-                            }catch (java.lang.ArrayIndexOutOfBoundsException exception) {
+                        output[8] = output[8].substring(2,output[8].length()-2);
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+tab+"martial" ) ) {
+                        output[10] = qaaa.split("=")[1];
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+tab+"finesse" ) ) {
+                        output[11] = qaaa.split("=")[1];
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+tab+"charisma" ) ) {
+                        output[12] = qaaa.split("=")[1];
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+tab+"zeal" ) ) {
+                        output[13] = qaaa.split("=")[1];
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"spouse" ) ) {
+                        output[14] = qaaa.split("=")[1];
+                        output[14] = output[14].substring(2,output[14].length()-2); 
 
+                        try {
+                            if (output[14].split(" ")[1] != null) {
+                                output[14] = output[14].split(" ")[output[14].split(" ").length-1];   
                             }
-                        }
-                        else if (qaaa.split("=")[0].equals( tab+"children" ) ) {
-
-                
-                            output[15] = qaaa.split("=")[1];
-                            output[15] = output[15].substring(2,output[15].length()-2);    
+                        }catch (java.lang.ArrayIndexOutOfBoundsException exception) {
 
                         }
+                    }
+                    else if (qaaa.split("=")[0].equals( tab+"children" ) ) {
 
-                        //popTotal
-                        else if (qaaa.split("=")[0].equals( tab+"age" ) ) {
-                            aqq = aqq + 1;
-                            output[3] = qaaa.split("=")[1];
+                        output[15] = qaaa.split("=")[1];
+                        output[15] = output[15].substring(2,output[15].length()-2);    
+
+                    }
+
+                    //popTotal
+                    else if (qaaa.split("=")[0].equals( tab+"age" ) ) {
+                        aqq = aqq + 1;
+                        output[3] = qaaa.split("=")[1];
+                    }
+
+                    //might be used or ignored
+                    else if (qaaa.equals( tab+"female=yes" ) ) {
+                        aqq = aqq + 1;
+                        output[4] = "f";
+                    }
+
+                    else if (qaaa.split("=")[0].equals( tab+"death_date" ) ) {
+                        aqq = aqq + 1;
+                        flag = 1; //end loop, babies which die don't have any experience field
+                        output[4] = output[4]+"_"+qaaa.split("=")[1];
+                        output[6] = "0";
+                    }
+
+                    else if (qaaa.split("=")[0].equals( tab+"character_experience" ) ) {
+                        aqq = aqq + 1;
+                        flag = 1; //end loop
+                        output[6] = qaaa.split("=")[1];
+                    }
+                    
+                    else if (qaaa.split("=")[0].equals( Integer.toString(impCharList.size()+1) ) ) { //Somehow has gone past checks, immediately end
+                        aqq = aqq + 1;
+                        flag = 1; //end loop
+                        output[6] = "0";
+                    }
+
+                    if (flag == 1) {
+
+                        String[] tmpOutput = new String[output.length];
+
+                        int aq2 = 0;
+
+                        while (aq2 < output.length) {
+                            tmpOutput[aq2] = output[aq2];
+                            aq2 = aq2 + 1;
                         }
 
-                        //might be used or ignored
-                        else if (qaaa.equals( tab+"female=yes" ) ) {
-                            aqq = aqq + 1;
-                            output[4] = "f";
-                        }
+                        impCharList.add(tmpOutput);
 
-                        else if (qaaa.split("=")[0].equals( tab+"death_date" ) ) {
-                            aqq = aqq + 1;
-                            flag = 1; //end loop, babies which die don't have any experience field
-                            output[4] = output[4]+"_"+qaaa.split("=")[1];
-                            output[6] = "0";
-                        }
-
-                        else if (qaaa.split("=")[0].equals( tab+"character_experience" ) ) {
-                            aqq = aqq + 1;
-                            flag = 1; //end loop
-                            output[6] = qaaa.split("=")[1];
-                        }
-
+                        output[0] = "noName"; //default for no owner, uncolonized province
+                        output[1] = "noCulture"; //default for no culture, uncolonized province with 0 pops
+                        output[2] = "noReligion"; //default for no religion, uncolonized province with 0 pops
+                        output[3] = "30"; //default age
+                        output[4] = "m"; //by default all characters are male, unless specified to be female
+                        output[7] = "q"; //default for no dynasty
+                        output[8] = "q"; //default for no traits
+                        output[10] = "0"; //default for no martial
+                        output[11] = "0"; //default for no finesse
+                        output[12] = "0"; //default for no charisma
+                        output[13] = "0"; //default for no zeal
+                        output[14] = "0"; //default for unmarried character
+                        output[15] = "0"; //default for character with no children
+                        output[16] = "0"; //default for minor character with no family name
                     }
 
                 }
@@ -150,10 +188,11 @@ public class Characters
 
         }   
 
-        return output;
-    
+        return impCharList;
+
     }
-    public static String importAndConvDynasty (String dir, String IDnum, String backupName, String file) throws IOException
+
+    public static ArrayList<String> importDynasty (String file) throws IOException
     {
 
         String tab = "	";
@@ -163,32 +202,49 @@ public class Characters
 
         int flag = 0;
 
-        String keyWord = tab+tab+IDnum;
-
         int aqq = 0;
         boolean endOrNot = true;
         String vmm = scnr.nextLine();
         String qaaa = vmm;
         String output = "noName"; //default for no name
 
-      
+        ArrayList<String> dynList= new ArrayList<String>();
+
+        String id = "0";
+
         try {
-            while (endOrNot = true){
+            try {
+                while (endOrNot = true){
 
-                qaaa = scnr.nextLine();
-                if (qaaa.split("=")[0].equals(keyWord)){
-                    endOrNot = false;
-                    while (flag == 0) {
-                        qaaa = scnr.nextLine();
-                        if (qaaa.split("=")[0].equals( tab+tab+tab+"key" ) ) {
-                            output = qaaa.split("=")[1];
-                            output = output.substring(1,output.length()-1);
-                            flag = 1;
+                    qaaa = scnr.nextLine();
+                    if (qaaa.equals(tab+tab+"}")) {
+                        int flag1 = 0;
+                        while (flag1 == 0) {
+                            qaaa = scnr.nextLine();
+                            if (qaaa.split("=")[0].equals( tab+tab+tab+"key" )) {
+                                flag1 = 1;
+                            } 
+                            else {
+                                id = qaaa.split(tab+tab)[1];
+                                id = id.split("=")[0];
+                            }
+
                         }
+                    }
+                    if (qaaa.split("=")[0].equals( tab+tab+tab+"key" )) {
 
+                        output = qaaa.split("=")[1];
+                        output = output.substring(1,output.length()-1);
+                        String tmpOutput = output+","+id;
+                        dynList.add(tmpOutput);
+                        output = "noName"; //default for no name
+                        aqq = aqq + 1;
+                        //flag = 1;
                     }
 
                 }
+            }catch(java.lang.ArrayIndexOutOfBoundsException exception) {
+                endOrNot = false;
             }
 
         }catch (java.util.NoSuchElementException exception){
@@ -196,16 +252,22 @@ public class Characters
 
         }   
 
-        if (output.split("_")[0].equals ("minor")) {
-            output = backupName;
+        return dynList;
+    }
+    
+    public static String searchDynasty (ArrayList<String> dynList, String id) throws IOException //searches dynList for id
+    {
+        int aqq = 0;
+        
+        while (aqq < dynList.size()) {
+            String[] dyn = dynList.get(aqq).split(",");
+            if (dyn[1].equals(id)) {
+                return dyn[0];
+            } else {
+                aqq = aqq + 1;
+            }
         }
 
-        IDnum = Integer.toString(Integer.parseInt(IDnum) + 700000000);  
-
-        Output.dynastyCreation(output,IDnum,dir);
-        return output;
-
-    
+        return id;
     }
 }
-

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Importer.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Importer.java
@@ -1,4 +1,4 @@
-package ImperatorToCK2; 
+package ImperatorToCK2;   
 
 import java.util.Scanner;
 import java.io.IOException;
@@ -1049,5 +1049,3 @@ public class Importer
     }
     //developed originally by Shinymewtwo99
 }
-
-

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Main.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Main.java
@@ -1,4 +1,4 @@
-package ImperatorToCK2; 
+package ImperatorToCK2;  
 
 import java.util.Scanner;
 import java.util.ArrayList;
@@ -135,6 +135,10 @@ public class Main
             convertedCharacters.add("0"); //Debug at id 0 so list will never be empty
 
             ArrayList<String> impSubjectInfo = new ArrayList<String>(); //Overlord-Subject relations
+            
+            ArrayList<String[]> impCharInfoList = new ArrayList<String[]>();
+            
+            ArrayList<String> impDynList = new ArrayList<String>();
 
             String[] impProvRegions = Processing.importRegionList(8500,impGameDir);
 
@@ -413,7 +417,7 @@ public class Main
             long countryTime = System.nanoTime();
             long countryTimeTot = (((countryTime - startTime) / 1000000000)/60);
             LOGGER.info("Country data imported after "+countryTimeTot+" minutes");
-            LOGGER.finest("65%");
+            LOGGER.finest("55%");
 
             LOGGER.config("and the culture is" + ck2ProvInfo[1][343]);
 
@@ -423,8 +427,15 @@ public class Main
             LOGGER.config(ck2TagTotals[343]);
 
             int totCountries = impTagInfo.size(); //ammount of IR countries in save file
+            
+            LOGGER.info("Importing subject data...");
 
             impSubjectInfo = Processing.generateSubjectList(totCountries+100,saveDiplo);
+            
+            LOGGER.info("Subject data imported after "+countryTimeTot+" minutes");
+            LOGGER.finest("65%");
+            
+            LOGGER.info("Copying default output...");
 
             //Default output, will be included in every conversion regardless of what occured in the save file
             Output.output("defaultOutput"+VM+"cultures"+VM+"00_cultures.txt",modDirectory+VM+"common"+VM+"cultures"+VM+"00_cultures.txt");
@@ -503,6 +514,12 @@ public class Main
             
             int empireRank = 350; //Ammount of holdings to be Empire
             
+            impCharInfoList = Characters.importChar(saveCharacters);
+            
+            impDynList = Characters.importDynasty(saveDynasty);
+            
+            //Array
+            
             try {
                 try {
                     while (flag == 0) {
@@ -553,13 +570,17 @@ public class Main
                                 }
 
                                 LOGGER.info (impTagInfo.get(aq4)[16] + " rules " + impTagInfo.get(aq4)[0] + "_" + aq4);
-                                Character = Characters.importChar(saveCharacters,impTagInfo.get(aq4)[16]);
+                                Character = impCharInfoList.get(Integer.parseInt(impTagInfo.get(aq4)[16]));
                                 convertedCharacters = Output.characterCreation(tempNum2, Output.cultureOutput(Character[1]),Output.religionOutput(Character[2]),
                                     Character[3],Character[0],Character[7],Character[4],Character[8],Character[10],Character[11],Character[12],Character[13],Character[14],
-                                    Character[15],saveCharacters,"q","q",convertedCharacters,modDirectory);
+                                    Character[15],saveCharacters,"q","q",convertedCharacters,impCharInfoList,modDirectory);
                                 LOGGER.config ("c");
 
-                                String rulerDynasty = Characters.importAndConvDynasty(modDirectory,Character[7],Character[16],saveDynasty);
+                                String rulerDynasty = Characters.searchDynasty(impDynList,Character[7]);
+                                
+                                
+                                
+                                Output.dynastyCreation(rulerDynasty,Character[7],Character[16],modDirectory);
 
                                 String[] locName = importer.importLocalisation(impGameDir,impTagInfo.get(aq4)[19],rulerDynasty);
                                 output.localizationCreation(locName,impTagInfo.get(aq4)[0],rank,modDirectory);
@@ -585,11 +606,11 @@ public class Main
 
                                         Output.titleCreation(govRegID,governorID,Processing.randomizeColor(),"no","none",subRank,impTagInfo.get(aq4)[0],modDirectory);
 
-                                        govCharacter = Characters.importChar(saveCharacters,governor);
+                                        govCharacter = impCharInfoList.get(Integer.parseInt(governor));
 
                                         convertedCharacters = Output.characterCreation(governorID, Output.cultureOutput(govCharacter[1]),Output.religionOutput(govCharacter[2]),govCharacter[3],
                                             govCharacter[0],govCharacter[7],govCharacter[4],govCharacter[8],govCharacter[10],govCharacter[11],govCharacter[12],govCharacter[13],
-                                            govCharacter[14],govCharacter[15],saveCharacters,"q","q",convertedCharacters,modDirectory);
+                                            govCharacter[14],govCharacter[15],saveCharacters,"q","q",convertedCharacters,impCharInfoList,modDirectory);
 
                                         String[] govLocName = importer.importLocalisation(impGameDir,govReg,"00Region00");
                                         govLocName[0] = locName[1] + " " + govLocName[0];
@@ -671,9 +692,9 @@ public class Main
                             
                             LOGGER.info("Uncolonized province at ID "+aq4+", creating chiefdom of "+importedInfo[0]+" led by "+dynCharName);
 
-                            Output.dynastyCreation("of "+importedInfo[0],ruler,modDirectory);
+                            Output.dynastyCreation("of "+importedInfo[0],ruler,"debug",modDirectory);
                             Output.characterCreation(ruler,dynCult,dynRel,dynCharAge,dynCharName,ruler,"69","q","5","5","5","5","0","0",
-                                saveCharacters,"q","q",convertedCharacters,modDirectory);
+                                saveCharacters,"q","q",convertedCharacters,impCharInfoList,modDirectory);
                             String greyShade = Processing.randomizeColorGrey();
 
                             Output.titleCreation("dynamic"+aq4,ruler,greyShade,"no",Integer.toString(aq4),"d","no_liege",modDirectory);

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Output.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Output.java
@@ -335,7 +335,7 @@ public class Output
 
     public static ArrayList<String> characterCreation(String irKING, String cult, String rel, String age, String name, String dynasty,
     String sex, String traits, String martial, String zeal, String charisma, String finesse, String spouse, String children,String tempFile,String father,
-    String mother,ArrayList<String> convertedList,String Directory) throws IOException
+    String mother,ArrayList<String> convertedList,ArrayList<String[]> charList,String Directory) throws IOException
     {
 
         int characterCount = 0;
@@ -387,10 +387,11 @@ public class Output
         int aq4 = 0;
 
         if (spouse != "0") {//Recursively calls to get rest of family
-            spouseInfo = Characters.importChar(tempFile,spouse);
+            int spouseID = Integer.parseInt(spouse);
+            spouseInfo = charList.get(spouseID);
 
             characterCreation( spouse1066,  cultureOutput(spouseInfo[1]),  religionOutput(spouseInfo[2]),  spouseInfo[3],  spouseInfo[0],  spouseInfo[7],
-                spouseInfo[4],  spouseInfo[8],  martial,  zeal,  charisma,  finesse,  "0",  "0", tempFile,"q",  "q",convertedList, Directory);
+                spouseInfo[4],  spouseInfo[8],  martial,  zeal,  charisma,  finesse,  "0",  "0", tempFile,"q",  "q",convertedList,charList, Directory);
         }
 
         if (children != "0") {
@@ -405,13 +406,15 @@ public class Output
 
             while (aq4 < childCount) {//Recursively calls to get rest of family
 
-                childInfo = Characters.importChar(tempFile,children.split(" ")[aq4]);
+                int childID = Integer.parseInt(children.split(" ")[aq4]);
+
+                childInfo = charList.get(childID);
                 //oldlogPrint ("Child " + aq4 + " out of " + childCount);
                 child1066 = Integer.toString( 1000000 + Integer.parseInt(children.split(" ")[aq4]) );
 
                 characterCreation( child1066,  cultureOutput(childInfo[1]),  religionOutput(childInfo[2]),  childInfo[3],  childInfo[0],  childInfo[7],
                     childInfo[4],  childInfo[8],  martial,  zeal,  charisma,  finesse,  childInfo[14],  childInfo[15], tempFile,irKING,spouse1066,
-                    convertedList,Directory);
+                    convertedList,charList,Directory);
 
                 aq4 = aq4 + 1;
             }
@@ -464,7 +467,7 @@ public class Output
         aqq = 0;
 
         Importer importer = new Importer();
-        
+
         //any filename with non-asci characters won't render in CK II, changed file output name to use GloriousCharacter instead of character name
         //in case player created interesting names in I:R
 
@@ -635,7 +638,7 @@ public class Output
         return convertedList;
     }
 
-    public static String dynastyCreation(String name, String id, String Directory) throws IOException
+    public static String dynastyCreation(String name, String id, String backupName, String Directory) throws IOException
     {
 
         String VM = "\\"; 
@@ -643,8 +646,18 @@ public class Output
         char VMq = '"';
         String tab = "	";
 
+        if (name.split("_")[0].equals ("minor")) {
+            name = backupName;
+        }
+
+        if (backupName.equals("debug")) { //gives all IR character dynasties + 700000000 to prevent conflict, generated ones (debug) use + 6000000
+        } else {
+
+            id = Integer.toString(Integer.parseInt(id) + 700000000);
+        }
+
         Directory = Directory + VM + "common" + VM + "dynasties";
-        String ck2CultureInfo ="a";   // Owner Culture Religeon PopTotal Buildings
+        String ck2CultureInfo ="a";   // debug output
         FileOutputStream fileOut= new FileOutputStream(Directory + VM + "c_" + id + ".txt");
         PrintWriter out = new PrintWriter(fileOut);
 
@@ -757,17 +770,14 @@ public class Output
 
         return ck2CultureInfo;
     }
-    
+
     public static void logPrint(String name) throws IOException //outputs to log.txt
     {
-        
+
         String logFile = "debugTest.txt";
 
-
         ArrayList<String> oldFile = new ArrayList<String>();
-        
         oldFile = Importer.importBasicFile(logFile);
-
 
         FileOutputStream fileOut= new FileOutputStream(logFile);
         PrintWriter out = new PrintWriter(fileOut);
@@ -793,12 +803,11 @@ public class Output
         fileOut.close();
 
     }
-    
+
     public static void logBlank() throws IOException //creates/replaces new log file
     {
-        
-        String logFile = "log.txt";
 
+        String logFile = "log.txt";
 
         FileOutputStream fileOut= new FileOutputStream(logFile);
         PrintWriter out = new PrintWriter(fileOut);
@@ -809,8 +818,5 @@ public class Output
         out.flush();
         fileOut.close();
 
-
     }
-
 }
-


### PR DESCRIPTION
Something went wrong with #PR 27, please use this one instead.

Rewrote character and dynasty importers for time efficiency. importChar() no longer imports a single character (String[]) from a save, but rather imports all characters and returns a list (ArrayList<String[]>) of them. Similarly with importDynasty(), which returns all dynasties (String) into a list (ArrayList<String>). importDynasty() required major structural changes to remain compatible with old 1.3 saves, so each dynasty is indexed, with their ID added to the end of the string after a comma (dynasty_name,idNum), which the new method searchDynasty (ArrayList<String> , String) can search through for a specific dynasty.