### PR TITLE
Uninhabited Province Bug Fix

### DIFF
--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Main.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Main.java
@@ -248,7 +248,7 @@ public class Main
 
             LOGGER.info("temp Countries created");
 
-            TempFiles.tempCreate(impDirSave, "provinces={", "road_network={", saveProvinces);
+            TempFiles.tempCreate(impDirSave, "provinces={", "}", saveProvinces);
 
             LOGGER.info("temp Provinces created");   
 
@@ -968,3 +968,4 @@ public class Main
         }
     }
 }
+

--- a/ImperatorToCk2/src/main/java/ImperatorToCK2/Processing.java
+++ b/ImperatorToCk2/src/main/java/ImperatorToCK2/Processing.java
@@ -1,5 +1,5 @@
 package ImperatorToCK2;  
-   
+      
 import java.util.Scanner;
 import java.io.IOException;
 import java.io.FileInputStream;
@@ -60,7 +60,7 @@ public class Processing
                 ownerTot[culRelID] = 0;    
             }
             else {
-                ownerTot[culRelID] = Integer.parseInt(owners[1]);
+                ownerTot[culRelID] = Integer.parseInt(owners[1])+1;
             }
 
             aq6 = 1;
@@ -1181,3 +1181,4 @@ public class Processing
     }
 
 }
+


### PR DESCRIPTION
Fixes a bug where if all of the I:R provinces that made up a CK2 province had no pops, the CK2 province would not be output. Also fixes a bug where the converter would crash if there were no roads in the save file