### PR TITLE
Shokka and Fezzan Fix

### DIFF
--- a/ImperatorToCk2/DataFiles/cultureConversion.txt
+++ b/ImperatorToCk2/DataFiles/cultureConversion.txt
@@ -542,6 +542,7 @@ pyu,pyu
 rhakine,mon
 mon,mon
 pubu,wa
+jaintia,mon
 
 #Chinese
 qin,han

--- a/ImperatorToCk2/src/main/java/com/paradoxgameconverters/irtockii/Importer.java
+++ b/ImperatorToCk2/src/main/java/com/paradoxgameconverters/irtockii/Importer.java
@@ -739,9 +739,14 @@ public class Importer
 
             try {
                 while (aqq < locList.size()){
+                    //In locList, mod loc strings are stored first, vanilla second
 
                     String qaaa = locList.get(aqq);
+                    qaaa = qaaa.replace(":1 ",":0 ");
                     qaaa = qaaa.replace(": ",":0 ");
+                    qaaa = qaaa.replace(":0  ",":0 "); //It is possible to have 2 spaces
+                    String[] qaaaSplit = qaaa.split(":");
+                    String qaaaIdentifier = qaaaSplit[0];
                     try {
                         if (qaaa.charAt(0) != ' ') {//If loc lacks leading space, add a space
                             qaaa = " " + qaaa;
@@ -750,8 +755,9 @@ public class Importer
                         
                     }
 
-                    if (qaaa.split(":")[0].equals(" "+tag)){
-                        output[0] = qaaa.split(":")[1];
+                    if (qaaaIdentifier.equals(" "+tag) && !name && !qaaaIdentifier.equals("")){
+                        //if previously found, will not overwrite first entry, and will ignore blank information (tag:0 "")
+                        output[0] = qaaaSplit[1];
                         output[0] = output[0].substring(3,output[0].length()-1);
                         name = true;
 
@@ -760,8 +766,8 @@ public class Importer
                     String adjName = tag.replace("_FEUDATORY_NAME","_FEUDATORY_ADJECTIVE"); //for certain mission tags which have different formatting
                     adjName = adjName.replace("_NAME","");
 
-                    if (qaaa.split(":")[0].equals(" "+tag+"_ADJ") || qaaa.split(":")[0].equals(" "+tag+"_ADJECTIVE")
-                    || qaaa.split(":")[0].equals(" "+adjName+"_ADJ") || qaaa.split(":")[0].equals(" "+adjName+"_ADJECTIVE")){
+                    if (qaaaIdentifier.equals(" "+tag+"_ADJ") || qaaaIdentifier.equals(" "+tag+"_ADJECTIVE") || qaaaIdentifier.equals(" "+adjName+"_ADJ")
+                    || qaaaIdentifier.equals(" "+adjName+"_ADJECTIVE")){
                         if (name) {
                           aqq = locList.size() + 1;  
                         }
@@ -1680,6 +1686,7 @@ public class Importer
             }
 
         }catch (java.util.NoSuchElementException exception){
+            //System.out.println("Error with importing flags from "+name+", skipping");
 
         }   
 
@@ -1906,13 +1913,14 @@ public class Importer
             aqq = aqq + 1;
         }
 
+        allLoc.addAll(moddedLoc); //Modded loc takes priority
         allLoc.addAll(regionLoc);
         allLoc.addAll(formableLoc);
         allLoc.addAll(countryLoc);
         allLoc.addAll(provLoc);
         allLoc.addAll(areaLoc);
         allLoc.addAll(supportedModLoc);
-        allLoc.addAll(moddedLoc);
+        //allLoc.addAll(moddedLoc);
 
         return allLoc;
     }

--- a/ImperatorToCk2/src/main/java/com/paradoxgameconverters/irtockii/Main.java
+++ b/ImperatorToCk2/src/main/java/com/paradoxgameconverters/irtockii/Main.java
@@ -34,7 +34,7 @@ public class Main
             throw new RuntimeException("Problems with creating the log files");
         }
 
-        LOGGER.info("Converter version 0.2A \"Belgae\" - compatible with Imperator: Rome 1.3-2.0 and Crusader Kings II 3.3");
+        LOGGER.info("Converter version 0.3 \"Carthaginian\" - compatible with Imperator: Rome 1.3-2.0 and Crusader Kings II 3.3");
         LOGGER.finest("0%");
         System.out.println("5%");
 
@@ -740,8 +740,18 @@ public class Main
 
 
                                 Output.dynastyCreation(rulerDynasty,Character[7],Character[16],modDirectory);
+                                
+                                String[] locName = new String[2];
+                                locName[0] = impTagInfo.get(aq4)[19];
+                                locName[1] = impTagInfo.get(aq4)[19];
 
-                                String[] locName = importer.importLocalisation(locList,impTagInfo.get(aq4)[19],rulerDynasty);
+                                try {
+                                    locName = importer.importLocalisation(locList,impTagInfo.get(aq4)[19],rulerDynasty);
+                                } catch (Exception e) {
+                                    LOGGER.warning("Exception created while generating loc "+impTagInfo.get(aq4)[19]+" for "+impTagInfo.get(aq4)[0]+
+                                    ", aborting loc generation");
+                                }
+                                
                                 Output.localizationCreation(locName,impTagInfo.get(aq4)[0],rank,modDirectory);
                                 if (oldName.equals(impTagInfo.get(aq4)[0])) { //Try to generate flag, if failure occurs, copy capital flag
                                     int genFlag = 0;


### PR DESCRIPTION
Fixes an edge-case where if a localization key was defined as blank (key:0 ""), the converter would attempt use it as valid localization, causing it to crash. Additionally, modded localization will now always take priority over vanilla localization, Fezzan now no longer converts with a quote in front, and adds a final failsafe, should the importLocalisation method raise an exception.