### PR TITLE
Excessive Character Crash Fix

### DIFF
--- a/ImperatorToCk2/src/main/java/com/paradoxgameconverters/irtockii/Characters.java
+++ b/ImperatorToCk2/src/main/java/com/paradoxgameconverters/irtockii/Characters.java
@@ -1,6 +1,5 @@
 package com.paradoxgameconverters.irtockii;
 
-
 import java.util.Scanner;
 import java.io.IOException;
 import java.io.FileInputStream;
@@ -18,7 +17,7 @@ public class Characters
 {
     private int x;
 
-    public static ArrayList<String[]> importChar (String name,int compressedOrNot) throws IOException
+    public static ArrayList<String[]> importChar (String name,int compressedOrNot,int cutoff) throws IOException
     {
 
         String tab = "	";
@@ -32,6 +31,8 @@ public class Characters
         String keyWord = "1={";
 
         int aqq = 0;
+        
+        int idCount = 0;
 
         ArrayList<String[]> impCharList= new ArrayList<String[]>();
 
@@ -186,8 +187,29 @@ public class Characters
                             tmpOutput[aq2] = output[aq2];
                             aq2 = aq2 + 1;
                         }
+                        
+                        int tmpSpouse = -1;
+                        
+                        if (!tmpOutput[14].equals("none")) {
+                            tmpSpouse = Integer.parseInt(tmpOutput[14]);
+                        }
+                        
+                        if (cutoff > -1) { //if relatives are above the cutoff point, purge in order to save memory
+                            //Children will never have an ID higher then their parents
+                            if (tmpSpouse < cutoff) {
+                                tmpOutput[14] = "0";
+                            }
+                        }
+                        
+                        if (cutoff <= -1 || idCount >= cutoff) { //Only add to memory if above the cutoff point
+                            impCharList.add(tmpOutput);
+                        } else {
+                            impCharList.add(null);
+                        }
+                        
+                        idCount = idCount + 1;
 
-                        impCharList.add(tmpOutput);
+                        //impCharList.add(tmpOutput);
 
                         output[0] = "noName"; //default for no owner, uncolonized province
                         output[1] = "noCulture"; //default for no culture, uncolonized province with 0 pops

--- a/ImperatorToCk2/src/main/java/com/paradoxgameconverters/irtockii/Main.java
+++ b/ImperatorToCk2/src/main/java/com/paradoxgameconverters/irtockii/Main.java
@@ -616,8 +616,27 @@ public class Main
             String govReg;
             String govRegID;
             String[] govCharacter;
+            
+            //int cutoffNum = 450000;
+            int cutoffNum = -1;
+            int emergencyCount = 5;
+            boolean characterLoop = true;
+            while (characterLoop && emergencyCount > 0) { //Will continously attempt with increasingly-high cutoffNum, up to emergencyCount
+                try {
+                    impCharInfoList = Characters.importChar(saveCharacters,compressedOrNot,cutoffNum);
+                    characterLoop = false;
+                } catch (java.lang.OutOfMemoryError exception){ //Replace likely long-dead characters with null as a fail-safe for memory-related crashes
+                    LOGGER.warning("Error! Ran out of memory while converting characters, attempting to purge characters below ID "+cutoffNum+".");
+                    //System.out.println("Error! Ran out of memory while converting characters, attempting to purge characters below ID "+cutoffNum+".");
+                    cutoffNum = cutoffNum + 450000;
+                } 
+                emergencyCount = emergencyCount - 1;
+                if (emergencyCount <= 0) {
+                    LOGGER.warning("Warning! Emergency cutoff point reached, aborting character conversion");
+                }
+            }
 
-            impCharInfoList = Characters.importChar(saveCharacters,compressedOrNot);
+            //impCharInfoList = Characters.importChar(saveCharacters,compressedOrNot,cutoffNum);
 
             impDynList = Characters.importDynasty(saveDynasty);
             


### PR DESCRIPTION
Fixes a crash that would occur if there are too many characters in the save file by introducing an artificial cutoff point when an exception occurs, similar to what was done in Bronze age to Imperator:Rome.